### PR TITLE
Release v1.0.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,4 @@
-appraise 'rails3.2' do
-  gem 'rails', '~> 3.2.0'
-  gem "strong_parameters", ">= 0.2", require: false
-end
-
+# frozen_string_literal: true
 appraise 'rails4.0' do
   gem 'rails', '~> 4.0.0'
   gem 'protected_attributes'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,13 @@
-source 'http://gems.railsc.ru'
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'test-unit'
 
 gemspec
+
+if RUBY_VERSION < '2.3'
+  gem 'pry-byebug', '< 3.7.0', require: false
+end
+
+# NameError: uninitialized constant Pry::Command::ExitAll при попытке выполнить require 'pry-byebug'
+gem 'pry', '< 0.13.0', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 # load everything from tasks/ directory
 Dir[File.join(File.dirname(__FILE__), 'tasks', '*.{rb,rake}')].each { |f| load(f) }
 

--- a/apress-page_info.gemspec
+++ b/apress-page_info.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'apress/page_info/version'
@@ -28,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'combustion'
   spec.add_development_dependency 'tzinfo'
   spec.add_development_dependency 'actionpack', '>= 3.2', '< 5.0'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubygems'
 require 'bundler'
 

--- a/dip.yml
+++ b/dip.yml
@@ -5,7 +5,6 @@ environment:
   RUBY_IMAGE_TAG: 2.2-latest
   COMPOSE_FILE_EXT: development
   RAILS_ENV: test
-  APRESS_GEMS_CREDENTIALS: ""
 
 compose:
   files:
@@ -38,11 +37,10 @@ interaction:
 
   clean:
     service: app
-    command: rm -f Gemfile.lock gemfiles/*.gemfile*
+    command: rm -rf Gemfile.lock gemfiles
 
 provision:
   - docker volume create --name bundler_data
-  - dip bundle config --local https://gems.railsc.ru/ ${APRESS_GEMS_CREDENTIALS}
   - dip clean
   - dip bundle install
   - dip appraisal install

--- a/lib/apress/page_info.rb
+++ b/lib/apress/page_info.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'apress/page_info/version'
 require 'active_support'
@@ -7,6 +8,9 @@ require 'apress/page_info/seo_config'
 module Apress
   module PageInfo
     extend ActiveSupport::Concern
+
+    CONTROLLER_NAME_TAIL = /Controller$/.freeze
+    PAGE_SEO_META = %w(title description keywords header promo_text).freeze
 
     autoload :Meta, 'apress/page_info/meta'
 
@@ -79,7 +83,7 @@ module Apress
     #
     # Returns nothing
     def seo_for_page
-      %w(title description keywords header promo_text).each do |meta|
+      PAGE_SEO_META.each do |meta|
         send("set_#{meta}_key", "#{seo_condition[:prefix]}#{meta}")
       end
 
@@ -90,7 +94,11 @@ module Apress
     #
     # Returns Array, list of different conditions
     def seo_config
-      Apress::PageInfo::SeoConfig.storage[:"#{controller_name}/#{action_name}"]
+      return @seo_config if defined?(@seo_config)
+
+      controller_fullname = self.class.name.sub(CONTROLLER_NAME_TAIL, '').underscore
+
+      @seo_config = Apress::PageInfo::SeoConfig.storage[:"#{controller_fullname}##{action_name}"]
     end
 
     # Internal: finds suitable condition of seo

--- a/lib/apress/page_info/meta.rb
+++ b/lib/apress/page_info/meta.rb
@@ -1,7 +1,15 @@
 # coding: utf-8
+# frozen_string_literal: true
 module Apress
   module PageInfo
     class Meta
+      CONTROLLER_TAIL = /_controller$/.freeze
+      private_constant :CONTROLLER_TAIL
+      SYMBOL_AFTER_SPACE = / ([\,\.\:\!])/.freeze
+      private_constant :SYMBOL_AFTER_SPACE
+      SPACES_RE = /[ ]+/.freeze
+      private_constant :SPACES_RE
+
       attr_accessor :controller
       alias_method :c, :controller
 
@@ -105,13 +113,14 @@ module Apress
         )
 
         return I18n.t!("#{action_scope.join('.')}.#{postfix_key}", vars) if postfix_key
+
         I18n.t!(action_key, vars)
       end
 
       def action_scope
         @action_scope ||= [
           :pages,
-          c.class.name.underscore.gsub('/', '.').gsub(/_controller$/, ''),
+          c.class.name.underscore.gsub('/', '.').sub(CONTROLLER_TAIL, ''),
           c.params[:action]
         ]
       end
@@ -119,7 +128,7 @@ module Apress
       def controller_scope
         @controller_scope ||= [
           :pages,
-          c.class.name.underscore.gsub('/', '.').gsub(/_controller$/, '')
+          c.class.name.underscore.gsub('/', '.').sub(CONTROLLER_TAIL, '')
         ]
       end
 
@@ -132,39 +141,46 @@ module Apress
       # это использовать в наследниках
       def set_title_variables(vars)
         raise ArgumentError unless vars.is_a?(Hash)
+
         @title_variables = vars.symbolize_keys
       end
 
       # это использовать в наследниках
       def set_title_key(key)
         raise ArgumentError unless key.is_a?(String)
+
         @title_key = key
       end
 
       def set_postfix_key(key)
         raise ArgumentError unless key.is_a?(String)
+
         @postfix_key = key
       end
 
       # это использовать в наследниках
       def set_header_key(key)
         raise ArgumentError unless key.is_a?(String)
+
         @header_key = key
       end
 
       # это использовать в наследниках
       def set_description_key(key)
         raise ArgumentError unless key.is_a?(String)
+
         @description_key = key
       end
 
       def set_keywords_key(key)
         raise ArgumentError unless key.is_a?(String)
+
         @keywords_key = key
       end
 
       def set_promo_text_key(key)
         raise ArgumentError unless key.is_a?(String)
+
         @promo_text_key = key
       end
 
@@ -185,7 +201,7 @@ module Apress
       end
 
       def compact_spaces(value)
-        value.gsub(/[ ]+/, ' ').gsub(/ ([\,\.\:\!])/, '\1')
+        value.gsub(SPACES_RE, ' ').gsub(SYMBOL_AFTER_SPACE, '\1')
       end
 
       def set_custom_description(description)

--- a/lib/apress/page_info/seo/dsl/condition.rb
+++ b/lib/apress/page_info/seo/dsl/condition.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 module Apress
   module PageInfo

--- a/lib/apress/page_info/seo/dsl/configuration.rb
+++ b/lib/apress/page_info/seo/dsl/configuration.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 module Apress
   module PageInfo

--- a/lib/apress/page_info/seo_config.rb
+++ b/lib/apress/page_info/seo_config.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'apress/page_info/seo/dsl/configuration'
 require 'apress/page_info/seo/dsl/condition'

--- a/lib/apress/page_info/version.rb
+++ b/lib/apress/page_info/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Apress
   module PageInfo
     VERSION = '0.5.0'.freeze

--- a/lib/apress/page_info/version.rb
+++ b/lib/apress/page_info/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Apress
   module PageInfo
-    VERSION = '0.5.0'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/spec/internal/config/locales/pages.yml
+++ b/spec/internal/config/locales/pages.yml
@@ -1,34 +1,35 @@
 ru:
   pages:
-    anonymous:
-      postfix: '- Awesome site'
-      index:
+    anonym:
+      anonymous:
+        postfix: '- Awesome site'
+        index:
+          foo:
+            title: 'foo title'
+            header: 'foo header'
+            description: 'foo description'
+            keywords: 'foo keywords'
+            promo_text: 'foo promo text'
+          seo_for_user:
+            title: 'hello user - %{foo}'
+            description: 'description for user - %{foo}'
+            keywords: 'keywords for user - %{foo}'
+            promo_text: 'promo text for user - %{foo}'
+            header: 'header for user - %{foo}'
+          seo_for_guest:
+            title: 'hello guest - %{foo}'
+            description: 'descritpion for guest - %{foo}'
+            keywords: 'keywords for guest - %{foo}'
+            promo_text: 'promo text for guest - %{foo}'
+            header: 'header for guest - %{foo}'
+          title: 'awesome title'
+          header: 'awesome header'
+          description: 'awesome descritpion'
+          keywords: 'awesome keywords'
+          promo_text: 'awesome promo text'
         foo:
-          title: 'foo title'
-          header: 'foo header'
-          description: 'foo description'
-          keywords: 'foo keywords'
-          promo_text: 'foo promo text'
-        seo_for_user:
-          title: 'hello user - %{foo}'
-          description: 'description for user - %{foo}'
-          keywords: 'keywords for user - %{foo}'
-          promo_text: 'promo text for user - %{foo}'
-          header: 'header for user - %{foo}'
-        seo_for_guest:
-          title: 'hello guest - %{foo}'
-          description: 'descritpion for guest - %{foo}'
-          keywords: 'keywords for guest - %{foo}'
-          promo_text: 'promo text for guest - %{foo}'
-          header: 'header for guest - %{foo}'
-        title: 'awesome title'
-        header: 'awesome header'
-        description: 'awesome descritpion'
-        keywords: 'awesome keywords'
-        promo_text: 'awesome promo text'
-      foo:
-        title: 'title with vars %{foo}'
-        header: 'header with vars %{foo}'
-        description: 'description with vars %{foo}'
-        keywords: 'keywords with vars %{foo}'
-        promo_text: 'promo text with vars %{foo}'
+          title: 'title with vars %{foo}'
+          header: 'header with vars %{foo}'
+          description: 'description with vars %{foo}'
+          keywords: 'keywords with vars %{foo}'
+          promo_text: 'promo text with vars %{foo}'

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.routes.draw do
   #
 end

--- a/spec/lib/apress/page_info/seo/dsl/condition_spec.rb
+++ b/spec/lib/apress/page_info/seo/dsl/condition_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 RSpec.describe Apress::PageInfo::Seo::Dsl::Condition do
   let(:cond) { described_class.new('foo_prefix') {} }

--- a/spec/lib/apress/page_info/seo/dsl/configuration_spec.rb
+++ b/spec/lib/apress/page_info/seo/dsl/configuration_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 RSpec.describe Apress::PageInfo::Seo::Dsl::Configuration do
   describe '#config' do

--- a/spec/lib/apress/page_info/seo_config_spec.rb
+++ b/spec/lib/apress/page_info/seo_config_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/lib/apress/page_info_spec.rb
+++ b/spec/lib/apress/page_info_spec.rb
@@ -1,9 +1,13 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
-AnonymousController = Class.new(ActionController::Base)
+module Anonym
+  class AnonymousController < ActionController::Base
+  end
+end
 
 RSpec.describe Apress::PageInfo, type: :controller do
-  controller AnonymousController do
+  controller Anonym::AnonymousController do
     include Apress::PageInfo
 
     define_seo_for :index
@@ -13,13 +17,13 @@ RSpec.describe Apress::PageInfo, type: :controller do
     end
   end
 
-  let(:postfix) { I18n.t('pages.anonymous.postfix') }
+  let(:postfix) { I18n.t('pages.anonym.anonymous.postfix') }
 
   before { allow(controller).to receive(:params).and_return(action: :index) }
 
   describe '#page_title' do
     context 'when default' do
-      it { expect(controller.page_title).to eq "#{I18n.t('pages.anonymous.index.title')}#{postfix}" }
+      it { expect(controller.page_title).to eq "#{I18n.t('pages.anonym.anonymous.index.title')}#{postfix}" }
     end
 
     context 'when last_error given' do
@@ -35,7 +39,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
         controller.send(:set_title_key, 'foo.title')
       end
 
-      it { expect(controller.page_title).to eq "#{I18n.t('pages.anonymous.index.foo.title')}#{postfix}" }
+      it { expect(controller.page_title).to eq "#{I18n.t('pages.anonym.anonymous.index.foo.title')}#{postfix}" }
     end
 
     context 'when not exist locale for given action' do
@@ -50,7 +54,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
         allow(controller).to receive(:params).and_return(action: :foo)
       end
 
-      it { expect(controller.page_title).to eq "#{I18n.t('pages.anonymous.foo.title', foo: :bar)}#{postfix}" }
+      it { expect(controller.page_title).to eq "#{I18n.t('pages.anonym.anonymous.foo.title', foo: :bar)}#{postfix}" }
     end
 
     context 'when setted custom title' do
@@ -64,7 +68,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
 
   describe '#page_header' do
     context 'when default' do
-      it { expect(controller.page_header).to eq I18n.t('pages.anonymous.index.header') }
+      it { expect(controller.page_header).to eq I18n.t('pages.anonym.anonymous.index.header') }
     end
 
     context 'when last_error given' do
@@ -80,7 +84,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
         controller.send(:set_header_key, 'foo.header')
       end
 
-      it { expect(controller.page_header).to eq I18n.t('pages.anonymous.index.foo.header') }
+      it { expect(controller.page_header).to eq I18n.t('pages.anonym.anonymous.index.foo.header') }
     end
 
     context 'when not exist locale for given action' do
@@ -96,7 +100,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
       end
 
       it do
-        expect(controller.page_header).to eq I18n.t('pages.anonymous.foo.header', foo: :bar)
+        expect(controller.page_header).to eq I18n.t('pages.anonym.anonymous.foo.header', foo: :bar)
       end
     end
 
@@ -111,7 +115,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
 
   describe '#page_description' do
     context 'when default' do
-      it { expect(controller.page_description).to eq I18n.t('pages.anonymous.index.description') }
+      it { expect(controller.page_description).to eq I18n.t('pages.anonym.anonymous.index.description') }
     end
 
     context 'when last_error given' do
@@ -127,7 +131,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
         controller.send(:set_description_key, 'foo.description')
       end
 
-      it { expect(controller.page_description).to eq I18n.t('pages.anonymous.index.foo.description') }
+      it { expect(controller.page_description).to eq I18n.t('pages.anonym.anonymous.index.foo.description') }
     end
 
     context 'when not exist locale for given action' do
@@ -142,7 +146,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
         allow(controller).to receive(:params).and_return(action: :foo)
       end
 
-      it { expect(controller.page_description).to eq I18n.t('pages.anonymous.foo.description', foo: :bar) }
+      it { expect(controller.page_description).to eq I18n.t('pages.anonym.anonymous.foo.description', foo: :bar) }
     end
 
     context 'when setted custom description' do
@@ -154,7 +158,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
 
   describe '#page_keywords' do
     context 'when default' do
-      it { expect(controller.page_keywords).to eq I18n.t('pages.anonymous.index.keywords') }
+      it { expect(controller.page_keywords).to eq I18n.t('pages.anonym.anonymous.index.keywords') }
     end
 
     context 'when last_error given' do
@@ -170,7 +174,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
         controller.send(:set_keywords_key, 'foo.keywords')
       end
 
-      it { expect(controller.page_keywords).to eq I18n.t('pages.anonymous.index.foo.keywords') }
+      it { expect(controller.page_keywords).to eq I18n.t('pages.anonym.anonymous.index.foo.keywords') }
     end
 
     context 'when not exist locale for given action' do
@@ -185,13 +189,13 @@ RSpec.describe Apress::PageInfo, type: :controller do
         allow(controller).to receive(:params).and_return(action: :foo)
       end
 
-      it { expect(controller.page_keywords).to eq I18n.t('pages.anonymous.foo.keywords', foo: :bar) }
+      it { expect(controller.page_keywords).to eq I18n.t('pages.anonym.anonymous.foo.keywords', foo: :bar) }
     end
   end
 
   describe '#page_promo_text' do
     context 'when default' do
-      it { expect(controller.page_promo_text).to eq I18n.t('pages.anonymous.index.promo_text') }
+      it { expect(controller.page_promo_text).to eq I18n.t('pages.anonym.anonymous.index.promo_text') }
     end
 
     context 'when last_error given' do
@@ -207,7 +211,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
         controller.send(:set_promo_text_key, 'foo.promo_text')
       end
 
-      it { expect(controller.page_promo_text).to eq I18n.t('pages.anonymous.index.foo.promo_text') }
+      it { expect(controller.page_promo_text).to eq I18n.t('pages.anonym.anonymous.index.foo.promo_text') }
     end
 
     context 'when not exist locale for given action' do
@@ -222,13 +226,13 @@ RSpec.describe Apress::PageInfo, type: :controller do
         allow(controller).to receive(:params).and_return(action: :foo)
       end
 
-      it { expect(controller.page_promo_text).to eq I18n.t('pages.anonymous.foo.promo_text', foo: :bar) }
+      it { expect(controller.page_promo_text).to eq I18n.t('pages.anonym.anonymous.foo.promo_text', foo: :bar) }
     end
   end
 
   describe '#title_postfix' do
     context 'when default' do
-      it { expect(controller.title_postfix).to eq I18n.t('pages.anonymous.postfix') }
+      it { expect(controller.title_postfix).to eq I18n.t('pages.anonym.anonymous.postfix') }
     end
   end
 
@@ -239,7 +243,7 @@ RSpec.describe Apress::PageInfo, type: :controller do
 
     before do
       Apress::PageInfo::SeoConfig.configure do
-        seo_for :'anonymous/index' do
+        seo_for :'anonym/anonymous#index' do
           config :seo_for_user do
             desc 'Seo meta for user'
             condition -> { signed_in? }
@@ -265,11 +269,11 @@ RSpec.describe Apress::PageInfo, type: :controller do
         get :index
 
         expect(controller.page_title).to eq(
-          "#{I18n.t('pages.anonymous.index.seo_for_guest.title', foo: 'fiz')}#{postfix}"
+          "#{I18n.t('pages.anonym.anonymous.index.seo_for_guest.title', foo: 'fiz')}#{postfix}"
         )
-        expect(controller.page_description).to eq I18n.t('pages.anonymous.index.seo_for_guest.description', foo: 'fiz')
-        expect(controller.page_keywords).to eq I18n.t('pages.anonymous.index.seo_for_guest.keywords', foo: 'fiz')
-        expect(controller.page_header).to eq I18n.t('pages.anonymous.index.seo_for_guest.header', foo: 'fiz')
+        expect(controller.page_description).to eq I18n.t('pages.anonym.anonymous.index.seo_for_guest.description', foo: 'fiz')
+        expect(controller.page_keywords).to eq I18n.t('pages.anonym.anonymous.index.seo_for_guest.keywords', foo: 'fiz')
+        expect(controller.page_header).to eq I18n.t('pages.anonym.anonymous.index.seo_for_guest.header', foo: 'fiz')
       end
     end
 
@@ -284,11 +288,11 @@ RSpec.describe Apress::PageInfo, type: :controller do
         get :index
 
         expect(controller.page_title).to eq(
-          "#{I18n.t('pages.anonymous.index.seo_for_user.title', foo: 'bar')}#{postfix}"
+          "#{I18n.t('pages.anonym.anonymous.index.seo_for_user.title', foo: 'bar')}#{postfix}"
         )
-        expect(controller.page_description).to eq I18n.t('pages.anonymous.index.seo_for_user.description', foo: 'bar')
-        expect(controller.page_keywords).to eq I18n.t('pages.anonymous.index.seo_for_user.keywords', foo: 'bar')
-        expect(controller.page_header).to eq I18n.t('pages.anonymous.index.seo_for_user.header', foo: 'bar')
+        expect(controller.page_description).to eq I18n.t('pages.anonym.anonymous.index.seo_for_user.description', foo: 'bar')
+        expect(controller.page_keywords).to eq I18n.t('pages.anonym.anonymous.index.seo_for_user.keywords', foo: 'bar')
+        expect(controller.page_header).to eq I18n.t('pages.anonym.anonymous.index.seo_for_user.header', foo: 'bar')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
-# coding: utf-8
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'simplecov'
+require 'pry-byebug'
 
 SimpleCov.start 'rails' do
   minimum_coverage 95
-  add_filter "apress/page_info/version.rb"
+  add_filter 'apress/page_info/version.rb'
 end
 
 require 'apress/page_info'


### PR DESCRIPTION
В новой версии добавился учет namespace контроллера. 
Для ПЦ это обернется внесением изменений в конфиг https://github.com/abak-press/pulscen/blob/7553299b788ff09721744f15df496b80c9409fa9/config/initializers/apress-page_info.rb#L15
Нужно:
1) заменить `/` разделяющие контроллер и экшен на `#` (по стандарту ruby on rails)
2) для AMP неймспейса вынести блок в переменную (константу), и два конфига пусть используют эту одну константу тогда в блоке
https://github.com/abak-press/pulscen/blob/7553299b788ff09721744f15df496b80c9409fa9/config/initializers/apress-page_info.rb#L334-L553